### PR TITLE
Use correct comparison operators

### DIFF
--- a/pdf2remarkable.sh
+++ b/pdf2remarkable.sh
@@ -73,9 +73,9 @@ fi
 
 RESTART_XOCHITL_DEFAULT=${RESTART_XOCHITL_DEFAULT:-0}
 RESTART_XOCHITL=${RESTART_XOCHITL_DEFAULT}
-if [ "$1" == "-r" ] ; then
+if [ "$1" = "-r" ] ; then
     shift
-    if [ $RESTART_XOCHITL_DEFAULT == 0 ] ; then
+    if [ $RESTART_XOCHITL_DEFAULT -eq 0 ] ; then
         echo Switching
         RESTART_XOCHITL=1
     else


### PR DESCRIPTION
Following https://stackoverflow.com/questions/10849297/compare-a-string-using-sh-shell

Before this change, I got the error`./pdf2remarkable.sh: 76: [: ==: unexpected operator` on Ubuntu 18.04, after which the script proceeded to attempt to copy a file called "-r" to the device when called with the `-r` flag.