### PR TITLE
Fix handling of file names beginning with dash

### DIFF
--- a/pdf2remarkable.sh
+++ b/pdf2remarkable.sh
@@ -95,7 +95,7 @@ for pdfname in "$@" ; do
     uuid=$(uuidgen)
 
     # Copy the PDF file itself
-    cp "$pdfname" ${tmpdir}/${uuid}.pdf
+    cp -- "$pdfname" ${tmpdir}/${uuid}.pdf
 
     # Add metadata
     # The lastModified item appears to contain the date in milliseconds since Epoch
@@ -110,7 +110,7 @@ for pdfname in "$@" ; do
     "synced": false,
     "type": "DocumentType",
     "version": 1,
-    "visibleName": "$(basename "$pdfname" .pdf)"
+    "visibleName": "$(basename -- "$pdfname" .pdf)"
 }
 EOF
 


### PR DESCRIPTION
pdf2remarkable.sh cannot handle file names that begin with a dash '-'.
Specifically, the `cp` and `basename` invocations fail, expecting an
option to follow:
```bash
$ pdf2remarkable.sh -\ foobar.pdf
cp: invalid option -- ' '
Try 'cp --help' for more information.
basename: invalid option -- ' '
Try 'basename --help' for more information.
...
```
This change fixes the issue by inserting a '--' separator to the two
commands in question.