### PR TITLE
Fix epub extension check

### DIFF
--- a/pdf2remarkable.sh
+++ b/pdf2remarkable.sh
@@ -150,7 +150,7 @@ EOF
 		# Add thumbnails directory
 		mkdir ${tmpdir}/${uuid}.thumbnails
 
-	elif [ "$extension" == "epub" ]; then
+	elif [ "$extension" = "epub" ]; then
 
 		# Add content information
 		cat <<EOF >${tmpdir}/${uuid}.content


### PR DESCRIPTION
Posix `test` command uses single `=` for string equality checks[0].

Before this fix the script would error with:

    153: [: epub: unexpected operator

[0]: https://pubs.opengroup.org/onlinepubs/009695399/utilities/test.html