### PR TITLE
Several improvements

### DIFF
--- a/pdf2remarkable.sh
+++ b/pdf2remarkable.sh
@@ -74,8 +74,12 @@ TARGET_DIR="${REMARKABLE_HOST}:${REMARKABLE_XOCHITL_DIR}"
 show_help ()
 {
     echo "Transfer PDF or EPUB document(s) to a reMarkable tablet."
-    echo "See comments/documentation at start of script."
-    echo "usage: $(basename $0) [-q|--quiet| [-r|--toggle-restart] [--uuids-file=<filename>] path-to-file [path-to-file]..."
+    echo "usage: $(basename $0) path-to-file [path-to-file]..."
+    echo "  -h  --help             print this usage information and exit"
+    echo "  -q  --quiet            don't print progress information"
+    echo "  -r  --toggle-restart   toggle whether to restart the tablet (default is given by RESTART_XOCHITL_DEFAULT)"
+    echo "      --uuids-file       write the list of uploaded files and their UUIDs to a file"
+    echo "See also comments/documentation at start of the script."
 }
 
 # Check if we have something to do

--- a/pdf2remarkable.sh
+++ b/pdf2remarkable.sh
@@ -225,7 +225,7 @@ EOF
     scp -r ${SCP_OPTIONS} ${tmpdir}/* "${TARGET_DIR}"
 
     # If successful, record the uuid to supplied file
-    [ $? -eq 0 ] && [ -n ${UUIDS_FILE} ] && echo "${uuid} ${filename}" >> ${UUIDS_FILE}
+    [ $? -eq 0 ] && [ -n "${UUIDS_FILE}" ] && echo "${uuid} ${filename}" >> ${UUIDS_FILE}
 
     # Clean up
     rm -rf ${tmpdir:?}/*

--- a/pdf2remarkable.sh
+++ b/pdf2remarkable.sh
@@ -203,17 +203,17 @@ EOF
 
     else
 	echo "Unknown extension: $extension, skipping $filename"
-        rm -rf ${tmpdir}/*
+        rm -rf ${tmpdir:?}/*
 	continue
     fi
 
     # Transfer files
     log "Transferring $filename as $uuid"
     scp -r ${SCP_OPTIONS} ${tmpdir}/* "${TARGET_DIR}"
-    rm -rf ${tmpdir}/*
+    rm -rf ${tmpdir:?}/*
 done
 
-rm -rf ${tmpdir}
+rm -rf ${tmpdir:?}
 
 if [ $RESTART_XOCHITL -eq 1 ] ; then
     log "Restarting Xochitl..."

--- a/pdf2remarkable.sh
+++ b/pdf2remarkable.sh
@@ -75,7 +75,7 @@ show_help ()
 {
     echo "Transfer PDF or EPUB document(s) to a reMarkable tablet."
     echo "See comments/documentation at start of script."
-    echo "usage: $(basename $0) [-q|--quiet| [-r|--toggle-restart] path-to-file [path-to-file]..."
+    echo "usage: $(basename $0) [-q|--quiet| [-r|--toggle-restart] [--uuids-file=<filename>] path-to-file [path-to-file]..."
 }
 
 # Check if we have something to do
@@ -89,6 +89,7 @@ RESTART_XOCHITL=${RESTART_XOCHITL_DEFAULT}
 
 BE_QUIET=0
 SCP_OPTIONS=
+UUIDS_FILE=
 
 # Print progess information
 log () {
@@ -117,6 +118,10 @@ while :; do
 	    else
 		RESTART_XOCHITL=0
 	    fi
+	    ;;
+	--uuids-file=?*)
+	    UUIDS_FILE=${1#*=}
+	    shift
 	    ;;
 	*)               # No more optional arguments 
 	    break  
@@ -214,6 +219,11 @@ EOF
     # Transfer files
     log "Transferring $filename as $uuid"
     scp -r ${SCP_OPTIONS} ${tmpdir}/* "${TARGET_DIR}"
+
+    # If successful, record the uuid to supplied file
+    [ $? -eq 0 ] && [ -n ${UUIDS_FILE} ] && echo "${uuid} ${filename}" >> ${UUIDS_FILE}
+
+    # Clean up
     rm -rf ${tmpdir:?}/*
 done
 

--- a/pdf2remarkable.sh
+++ b/pdf2remarkable.sh
@@ -125,6 +125,10 @@ done
 
 # Create directory where we prepare the files as the reMarkable expects them
 tmpdir=$(mktemp -d)
+if [ $? -ne 0 ]; then
+    echo "Cannot create a temporary directory. Exiting."
+    exit 1
+fi
 
 # Loop over the command line arguments,
 # which we expect are paths to the files to be transferred

--- a/pdf2remarkable.sh
+++ b/pdf2remarkable.sh
@@ -74,7 +74,7 @@ TARGET_DIR="${REMARKABLE_HOST}:${REMARKABLE_XOCHITL_DIR}"
 show_help ()
 {
     echo "Transfer PDF or EPUB document(s) to a reMarkable tablet."
-    echo "usage: $(basename $0) path-to-file [path-to-file]..."
+    echo "usage: $(basename $0) [options] path-to-file [path-to-file]..."
     echo "  -h  --help             print this usage information and exit"
     echo "  -q  --quiet            don't print progress information"
     echo "  -r  --toggle-restart   toggle whether to restart the tablet (default is given by RESTART_XOCHITL_DEFAULT)"


### PR DESCRIPTION
* Quiet option to suppress the log messages
* More usage help
* A bit of error-handling and paranoia
* An option to save the list of uploaded files and their UUIDs to a file

One thing that I would have preferred is to have the "-r|--restart" option to force the restart, as opposed to the current toggle behavior. However, I kept the old behavior for backwards-compatibility.